### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -1,4 +1,6 @@
 name: Proof HTML
+permissions:
+  contents: read
 on:
   push:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/rabbitmq-tester/security/code-scanning/2](https://github.com/conorheffron/rabbitmq-tester/security/code-scanning/2)

The problem should be fixed by explicitly defining the `permissions` block at the root level of the workflow, since there is only one job. The most minimal correct permissions set for a workflow that only reads and checks files is:

```yml
permissions:
  contents: read
```

This grants read-only access to repository contents for the GITHUB_TOKEN, preventing surprising writes. The permissions block should be inserted directly after the workflow’s `name` and before the `on:` block (or after, but before jobs). No other YAML regions or logic need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
