### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,5 +33,5 @@ jobs:
       run: mvn -B package --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+    # - name: Update dependency graph
+    #   uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/rabbitmq-tester/security/code-scanning/3](https://github.com/conorheffron/rabbitmq-tester/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to define the minimal set of permissions needed for the jobs. The best solution is to set the `permissions` at the workflow root level (just after the `name:` and before `jobs:`), so all jobs inherit the same permissions unless specifically overridden. For most Maven CI workflows, `contents: read` is sufficient to perform checkouts, builds, and dependency submissions unless additional write permissions are needed for actions that modify pull requests or repository contents. If actions requiring more permissions are added later (such as those that open issues or PRs, or perform releases), those permissions can be broadened in the future or for individual jobs.

Therefore, add the following block to the root of the workflow, after the `name:` key:
```yaml
permissions:
  contents: read
```
No imports or additional tokens are required; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
